### PR TITLE
Update core, so that event message are never dropped on second try.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
     environment:
       MESSAGE_BROKER_ADDRESS: rabbitmq
       API_HOST: http://gobapi:8001
+      GOB_SHARED_DIR: /app/shared
+    volumes:
+      - gob-volume:/app/shared
 
 networks:
   default:

--- a/src/gobkafkaproducer/__main__.py
+++ b/src/gobkafkaproducer/__main__.py
@@ -54,7 +54,7 @@ def new_events_handler(msg):
             headers=headers,
         )
 
-    producer.flush()
+    producer.flush(timeout=30)
     print(f"Sent {len(msg['contents'])} events to Kafka")
 
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,5 @@
 flake8==3.7.9
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.17.0b#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.17.0c#egg=gobcore
 pytest==3.6.3
 pytest-cov==2.5.1
 kafka-python==2.0.2


### PR DESCRIPTION
Add timeout to kafka producer flush call
Fix gob shared volume config